### PR TITLE
Allows the User to edit a Card's description

### DIFF
--- a/app/src/main/java/com/example/projectmanager_android/BoardActivity.java
+++ b/app/src/main/java/com/example/projectmanager_android/BoardActivity.java
@@ -119,7 +119,7 @@ public class BoardActivity extends AppCompatActivity implements CardDisplayer {
     @Override
     public void displayCardExpandedFragment(int cardId) {
         Card card = AppDataBase.getInstance(this).CardDAO().getCardByCardId(cardId);
-        mCardExpandedFragment = CardExpandedFragment.newInstance(card.getTitle(), card.getDescription());
+        mCardExpandedFragment = CardExpandedFragment.newInstance(card.getTitle(), card.getDescription(), card);
         getSupportFragmentManager().beginTransaction()
                 .add(android.R.id.content, mCardExpandedFragment)
                 .addToBackStack(null)

--- a/app/src/main/java/com/example/projectmanager_android/CardDescriptionEditorFragment.java
+++ b/app/src/main/java/com/example/projectmanager_android/CardDescriptionEditorFragment.java
@@ -1,0 +1,64 @@
+package com.example.projectmanager_android;
+
+import android.os.Bundle;
+
+import androidx.fragment.app.Fragment;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+/**
+ * A simple {@link Fragment} subclass.
+ * Use the {@link CardDescriptionEditorFragment#newInstance} factory method to
+ * create an instance of this fragment.
+ */
+public class CardDescriptionEditorFragment extends Fragment {
+
+    // TODO: Rename parameter arguments, choose names that match
+    // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
+    private static final String ARG_PARAM1 = "param1";
+    private static final String ARG_PARAM2 = "param2";
+
+    // TODO: Rename and change types of parameters
+    private String mParam1;
+    private String mParam2;
+
+    public CardDescriptionEditorFragment() {
+        // Required empty public constructor
+    }
+
+    /**
+     * Use this factory method to create a new instance of
+     * this fragment using the provided parameters.
+     *
+     * @param param1 Parameter 1.
+     * @param param2 Parameter 2.
+     * @return A new instance of fragment CardDescriptionEditorFragment.
+     */
+    // TODO: Rename and change types and number of parameters
+    public static CardDescriptionEditorFragment newInstance(String param1, String param2) {
+        CardDescriptionEditorFragment fragment = new CardDescriptionEditorFragment();
+        Bundle args = new Bundle();
+        args.putString(ARG_PARAM1, param1);
+        args.putString(ARG_PARAM2, param2);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (getArguments() != null) {
+            mParam1 = getArguments().getString(ARG_PARAM1);
+            mParam2 = getArguments().getString(ARG_PARAM2);
+        }
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        // Inflate the layout for this fragment
+        return inflater.inflate(R.layout.fragment_card_description_editor, container, false);
+    }
+}

--- a/app/src/main/java/com/example/projectmanager_android/CardDescriptionEditorFragment.java
+++ b/app/src/main/java/com/example/projectmanager_android/CardDescriptionEditorFragment.java
@@ -28,6 +28,7 @@ public class CardDescriptionEditorFragment extends Fragment {
 
 
     private TextView mCancelButton;
+    private TextView mDoneButton;
     private EditText mCardDescEditText;
 
     public CardDescriptionEditorFragment() {
@@ -66,6 +67,7 @@ public class CardDescriptionEditorFragment extends Fragment {
         View view = inflater.inflate(R.layout.fragment_card_description_editor, container, false);
 
         mCancelButton = view.findViewById(R.id.cardDescFragment_cancelButton);
+        mDoneButton = view.findViewById(R.id.cardDescFragment_DoneButton);
         mCardDescEditText = view.findViewById(R.id.cardDescFragment_description_EditText);
 
         mCardDescEditText.setText(mCardDescParam);
@@ -78,6 +80,19 @@ public class CardDescriptionEditorFragment extends Fragment {
             }
         });
 
+        mDoneButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if(cardDescChanged()){
+                    // TODO: Signal the CardExpandedFragment to set this card's description to what is currently contained in this mCardDescEditText.
+
+                    // TODO: If the above doesn't adjust the cardDesc in the CardExpandedFragment, update it manually
+
+                    removeFragment();
+                }
+            }
+        });
+
         return view;
     }
 
@@ -85,4 +100,7 @@ public class CardDescriptionEditorFragment extends Fragment {
         getParentFragmentManager().beginTransaction().remove(CardDescriptionEditorFragment.this).commit();
     }
 
+    private boolean cardDescChanged(){
+        return !mCardDescEditText.getEditableText().toString().equals(mCardDescParam);
+    }
 }

--- a/app/src/main/java/com/example/projectmanager_android/CardDescriptionEditorFragment.java
+++ b/app/src/main/java/com/example/projectmanager_android/CardDescriptionEditorFragment.java
@@ -19,12 +19,9 @@ import com.example.projectmanager_android.DB.AppDataBase;
  */
 public class CardDescriptionEditorFragment extends Fragment {
 
-    // TODO: Rename parameter arguments, choose names that match
     // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
     private static final String CARD_DESC_PARAM = "cardDesc";
-    private static final String ARG_PARAM2 = "param2";
 
-    // TODO: Rename and change types of parameters
     private String mCardDescParam;
     private CardExpandedFragment mCardExpandedFragment;
 
@@ -86,8 +83,6 @@ public class CardDescriptionEditorFragment extends Fragment {
             @Override
             public void onClick(View v) {
                 if(cardDescChanged()){
-                    // TODO: Signal the CardExpandedFragment to set this card's description to what is currently contained in this mCardDescEditText.
-                    // TODO: If the above doesn't adjust the cardDesc in the CardExpandedFragment, update it manually
                     mCardExpandedFragment.saveCardDesc(mCardDescEditText.getEditableText().toString());
                     removeFragment();
                 }

--- a/app/src/main/java/com/example/projectmanager_android/CardDescriptionEditorFragment.java
+++ b/app/src/main/java/com/example/projectmanager_android/CardDescriptionEditorFragment.java
@@ -7,6 +7,8 @@ import androidx.fragment.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.EditText;
+import android.widget.TextView;
 
 /**
  * A simple {@link Fragment} subclass.
@@ -17,12 +19,16 @@ public class CardDescriptionEditorFragment extends Fragment {
 
     // TODO: Rename parameter arguments, choose names that match
     // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
-    private static final String ARG_PARAM1 = "param1";
+    private static final String CARD_DESC_PARAM = "cardDesc";
     private static final String ARG_PARAM2 = "param2";
 
     // TODO: Rename and change types of parameters
-    private String mParam1;
+    private String mCardDescParam;
     private String mParam2;
+
+
+    private TextView mCancelButton;
+    private EditText mCardDescEditText;
 
     public CardDescriptionEditorFragment() {
         // Required empty public constructor
@@ -32,16 +38,14 @@ public class CardDescriptionEditorFragment extends Fragment {
      * Use this factory method to create a new instance of
      * this fragment using the provided parameters.
      *
-     * @param param1 Parameter 1.
-     * @param param2 Parameter 2.
+     * @param cardDesc Parameter 1.
      * @return A new instance of fragment CardDescriptionEditorFragment.
      */
     // TODO: Rename and change types and number of parameters
-    public static CardDescriptionEditorFragment newInstance(String param1, String param2) {
+    public static CardDescriptionEditorFragment newInstance(String cardDesc) {
         CardDescriptionEditorFragment fragment = new CardDescriptionEditorFragment();
         Bundle args = new Bundle();
-        args.putString(ARG_PARAM1, param1);
-        args.putString(ARG_PARAM2, param2);
+        args.putString(CARD_DESC_PARAM, cardDesc);
         fragment.setArguments(args);
         return fragment;
     }
@@ -50,7 +54,7 @@ public class CardDescriptionEditorFragment extends Fragment {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         if (getArguments() != null) {
-            mParam1 = getArguments().getString(ARG_PARAM1);
+            mCardDescParam = getArguments().getString(CARD_DESC_PARAM);
             mParam2 = getArguments().getString(ARG_PARAM2);
         }
     }
@@ -59,6 +63,26 @@ public class CardDescriptionEditorFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_card_description_editor, container, false);
+        View view = inflater.inflate(R.layout.fragment_card_description_editor, container, false);
+
+        mCancelButton = view.findViewById(R.id.cardDescFragment_cancelButton);
+        mCardDescEditText = view.findViewById(R.id.cardDescFragment_description_EditText);
+
+        mCardDescEditText.setText(mCardDescParam);
+
+
+        mCancelButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                removeFragment();
+            }
+        });
+
+        return view;
     }
+
+    private void removeFragment(){
+        getParentFragmentManager().beginTransaction().remove(CardDescriptionEditorFragment.this).commit();
+    }
+
 }

--- a/app/src/main/java/com/example/projectmanager_android/CardDescriptionEditorFragment.java
+++ b/app/src/main/java/com/example/projectmanager_android/CardDescriptionEditorFragment.java
@@ -10,6 +10,8 @@ import android.view.ViewGroup;
 import android.widget.EditText;
 import android.widget.TextView;
 
+import com.example.projectmanager_android.DB.AppDataBase;
+
 /**
  * A simple {@link Fragment} subclass.
  * Use the {@link CardDescriptionEditorFragment#newInstance} factory method to
@@ -24,7 +26,7 @@ public class CardDescriptionEditorFragment extends Fragment {
 
     // TODO: Rename and change types of parameters
     private String mCardDescParam;
-    private String mParam2;
+    private CardExpandedFragment mCardExpandedFragment;
 
 
     private TextView mCancelButton;
@@ -43,11 +45,12 @@ public class CardDescriptionEditorFragment extends Fragment {
      * @return A new instance of fragment CardDescriptionEditorFragment.
      */
     // TODO: Rename and change types and number of parameters
-    public static CardDescriptionEditorFragment newInstance(String cardDesc) {
+    public static CardDescriptionEditorFragment newInstance(String cardDesc, CardExpandedFragment cardExpandedFragment) {
         CardDescriptionEditorFragment fragment = new CardDescriptionEditorFragment();
         Bundle args = new Bundle();
         args.putString(CARD_DESC_PARAM, cardDesc);
         fragment.setArguments(args);
+        fragment.setCardExpandedFragment(cardExpandedFragment);
         return fragment;
     }
 
@@ -56,7 +59,6 @@ public class CardDescriptionEditorFragment extends Fragment {
         super.onCreate(savedInstanceState);
         if (getArguments() != null) {
             mCardDescParam = getArguments().getString(CARD_DESC_PARAM);
-            mParam2 = getArguments().getString(ARG_PARAM2);
         }
     }
 
@@ -85,9 +87,8 @@ public class CardDescriptionEditorFragment extends Fragment {
             public void onClick(View v) {
                 if(cardDescChanged()){
                     // TODO: Signal the CardExpandedFragment to set this card's description to what is currently contained in this mCardDescEditText.
-
                     // TODO: If the above doesn't adjust the cardDesc in the CardExpandedFragment, update it manually
-
+                    mCardExpandedFragment.saveCardDesc(mCardDescEditText.getEditableText().toString());
                     removeFragment();
                 }
             }
@@ -98,6 +99,10 @@ public class CardDescriptionEditorFragment extends Fragment {
 
     private void removeFragment(){
         getParentFragmentManager().beginTransaction().remove(CardDescriptionEditorFragment.this).commit();
+    }
+
+    private void setCardExpandedFragment(CardExpandedFragment cardExpandedFragment){
+        mCardExpandedFragment = cardExpandedFragment;
     }
 
     private boolean cardDescChanged(){

--- a/app/src/main/java/com/example/projectmanager_android/CardExpandedFragment.java
+++ b/app/src/main/java/com/example/projectmanager_android/CardExpandedFragment.java
@@ -10,6 +10,8 @@ import android.view.ViewGroup;
 import android.widget.ImageButton;
 import android.widget.TextView;
 
+import com.example.projectmanager_android.DB.Card;
+
 /**
  * A simple {@link Fragment} subclass.
  * Use the {@link CardExpandedFragment#newInstance} factory method to
@@ -28,6 +30,8 @@ public class CardExpandedFragment extends Fragment {
 
     private ImageButton mExitFragmentButton;
     private ImageButton mOptionsButton;
+
+    private Card mCard;
 
     public CardExpandedFragment() {
         // Required empty public constructor
@@ -97,10 +101,17 @@ public class CardExpandedFragment extends Fragment {
     }
 
     private void openCardDescription(){
-        CardDescriptionEditorFragment cardDescriptionEditorFragment = CardDescriptionEditorFragment.newInstance(mCardDescParam);
+        CardDescriptionEditorFragment cardDescriptionEditorFragment = CardDescriptionEditorFragment.newInstance(mCardDescParam, this);
         getParentFragmentManager().beginTransaction()
                 .add(android.R.id.content, cardDescriptionEditorFragment)
                 .addToBackStack(null)
                 .commit();
+    }
+
+    public void saveCardDesc(String newCardDesc){
+        // TODO: Save the cardDesc to the current card.
+
+        // TODO: Update the currently displayed CardDesc
+        mCardDescription.setText(newCardDesc);
     }
 }

--- a/app/src/main/java/com/example/projectmanager_android/CardExpandedFragment.java
+++ b/app/src/main/java/com/example/projectmanager_android/CardExpandedFragment.java
@@ -17,12 +17,9 @@ import android.widget.TextView;
  */
 public class CardExpandedFragment extends Fragment {
 
-    // TODO: Rename parameter arguments, choose names that match
-    // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
     private static final String CARD_TITLE_PARAM = "cardTitle";
     private static final String CARD_DESC_PARAM = "cardDesc";
 
-    // TODO: Rename and change types of parameters
     private String mCardTitleParam;
     private String mCardDescParam;
 
@@ -44,7 +41,6 @@ public class CardExpandedFragment extends Fragment {
      * @param cardDesc Parameter 2.
      * @return A new instance of fragment CardExpandedFragment.
      */
-    // TODO: Rename and change types and number of parameters
     public static CardExpandedFragment newInstance(String cardTitle, String cardDesc) {
         CardExpandedFragment fragment = new CardExpandedFragment();
         Bundle args = new Bundle();
@@ -86,10 +82,25 @@ public class CardExpandedFragment extends Fragment {
             }
         });
 
+        mCardDescription.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                openCardDescription();
+            }
+        });
+
         return view;
     }
 
     private void removeFragment(){
         getParentFragmentManager().beginTransaction().remove(CardExpandedFragment.this).commit();
+    }
+
+    private void openCardDescription(){
+        CardDescriptionEditorFragment cardDescriptionEditorFragment = CardDescriptionEditorFragment.newInstance(mCardDescParam);
+        getParentFragmentManager().beginTransaction()
+                .add(android.R.id.content, cardDescriptionEditorFragment)
+                .addToBackStack(null)
+                .commit();
     }
 }

--- a/app/src/main/java/com/example/projectmanager_android/CardExpandedFragment.java
+++ b/app/src/main/java/com/example/projectmanager_android/CardExpandedFragment.java
@@ -10,6 +10,7 @@ import android.view.ViewGroup;
 import android.widget.ImageButton;
 import android.widget.TextView;
 
+import com.example.projectmanager_android.DB.AppDataBase;
 import com.example.projectmanager_android.DB.Card;
 
 /**
@@ -45,12 +46,13 @@ public class CardExpandedFragment extends Fragment {
      * @param cardDesc Parameter 2.
      * @return A new instance of fragment CardExpandedFragment.
      */
-    public static CardExpandedFragment newInstance(String cardTitle, String cardDesc) {
+    public static CardExpandedFragment newInstance(String cardTitle, String cardDesc, Card card) {
         CardExpandedFragment fragment = new CardExpandedFragment();
         Bundle args = new Bundle();
         args.putString(CARD_TITLE_PARAM, cardTitle);
         args.putString(CARD_DESC_PARAM, cardDesc);
         fragment.setArguments(args);
+        fragment.setCard(card);
         return fragment;
     }
 
@@ -108,10 +110,15 @@ public class CardExpandedFragment extends Fragment {
                 .commit();
     }
 
-    public void saveCardDesc(String newCardDesc){
-        // TODO: Save the cardDesc to the current card.
+    private void setCard(Card card){
+        mCard = card;
+    }
 
-        // TODO: Update the currently displayed CardDesc
+    public void saveCardDesc(String newCardDesc){
+        // Updating the cardDesc of the current card.
+        mCard.setDescription(newCardDesc);
+        AppDataBase.getInstance(getContext()).CardDAO().update(mCard);
+        // Updating the currently displayed cardDesc
         mCardDescription.setText(newCardDesc);
     }
 }

--- a/app/src/main/res/layout/fragment_card_description_editor.xml
+++ b/app/src/main/res/layout/fragment_card_description_editor.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#1e1e1e"
+    android:clickable="true"
+    android:longClickable="true"
+    tools:context=".CardDescriptionEditorFragment">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/cardDescFragment_headerLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageButton
+            android:id="@+id/cardFragmentDesc_exitButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/baseline_close_24"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/cardDescFragment_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/card_description_fragment_header"
+            android:textColor="#cecece"
+            android:textSize="22sp"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/cardDescFragment_toolbarButton"
+            app:layout_constraintStart_toEndOf="@id/cardFragmentDesc_exitButton"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <ImageButton
+            android:id="@+id/cardDescFragment_toolbarButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:backgroundTint="#1e1e1e"
+            android:src="@drawable/baseline_more_horiz_24_white"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <LinearLayout
+        android:id="@+id/cardDescFragment_description_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="#2e2e2e"
+        android:minHeight="200dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/cardDescFragment_headerLayout">
+
+        <EditText
+            android:id="@+id/cardDescFragment_description_EditText"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:gravity="start"
+            android:hint="@string/start_of_your_card_description"
+            android:paddingHorizontal="10dp"
+            android:textColor="#cecece"
+            android:textColorHint="#888888"
+            android:textSize="18sp"
+            android:textStyle="normal" />
+    </LinearLayout>
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_card_description_editor.xml
+++ b/app/src/main/res/layout/fragment_card_description_editor.xml
@@ -13,15 +13,17 @@
         android:id="@+id/cardDescFragment_headerLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:paddingHorizontal="10dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
-        <ImageButton
-            android:id="@+id/cardFragmentDesc_exitButton"
+        <TextView
+            android:id="@+id/cardDescFragment_cancelButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:src="@drawable/baseline_close_24"
+            android:text="@string/cancel_text"
+            android:textColor="@color/white"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
@@ -35,16 +37,16 @@
             android:textSize="22sp"
             android:textStyle="bold"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@+id/cardDescFragment_toolbarButton"
-            app:layout_constraintStart_toEndOf="@id/cardFragmentDesc_exitButton"
+            app:layout_constraintEnd_toStartOf="@+id/cardDescFragment_DoneButton"
+            app:layout_constraintStart_toEndOf="@id/cardDescFragment_cancelButton"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <ImageButton
-            android:id="@+id/cardDescFragment_toolbarButton"
+        <TextView
+            android:id="@+id/cardDescFragment_DoneButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:backgroundTint="#1e1e1e"
-            android:src="@drawable/baseline_more_horiz_24_white"
+            android:text="@string/done_text"
+            android:textColor="@color/white"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/fragment_card_expanded.xml
+++ b/app/src/main/res/layout/fragment_card_expanded.xml
@@ -86,7 +86,7 @@
                 android:hint="Tap to add a description"
                 android:textColorHint="#cecece"
                 android:textColor="#cecece"
-                android:textSize="16sp"
+                android:textSize="18sp"
                 android:background="#2e2e2e"
                 android:paddingHorizontal="10dp"
                 android:paddingVertical="10dp"

--- a/app/src/main/res/layout/fragment_card_expanded.xml
+++ b/app/src/main/res/layout/fragment_card_expanded.xml
@@ -5,7 +5,10 @@
     android:layout_height="match_parent"
     android:background="#1e1e1e"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    tools:context=".CardExpandedFragment">
+    tools:context=".CardExpandedFragment"
+    android:clickable="true"
+    android:longClickable="true"
+    >
 
     <!-- TODO: Update blank fragment layout -->
 
@@ -51,18 +54,21 @@
             android:id="@+id/cardFragment_titleLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingHorizontal="10dp"
-            android:paddingVertical="10dp"
-            android:background="#2e2e2e"
+            android:paddingVertical="4dp"
+
             >
             <TextView
                 android:id="@+id/cardFragment_title"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="Card Title Placeholder"
                 android:textColor="#cecece"
                 android:textStyle="bold"
                 android:textSize="22sp"
+
+                android:paddingHorizontal="10dp"
+                android:paddingVertical="10dp"
+                android:background="#2e2e2e"
                 />
         </LinearLayout>
 
@@ -70,18 +76,20 @@
             android:id="@+id/cardFragment_descriptionLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingHorizontal="10dp"
-            android:paddingVertical="10dp"
-            android:background="#2e2e2e"
+            android:paddingVertical="4dp"
             app:layout_constraintTop_toBottomOf="@+id/cardFragment_title">
 
             <TextView
                 android:id="@+id/cardFragment_descriptionTextView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Card Description Placeholder. Card Description Placeholder. Card Description Placeholder. Card Description Placeholder. Card Description Placeholder. Card Description Placeholder. Card Description Placeholder. Card Description Placeholder."
+                android:hint="Tap to add a description"
+                android:textColorHint="#cecece"
                 android:textColor="#cecece"
                 android:textSize="16sp"
+                android:background="#2e2e2e"
+                android:paddingHorizontal="10dp"
+                android:paddingVertical="10dp"
                 />
         </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,4 +26,6 @@
     <string name="CardList_addCard_text">+ Add Card</string>
     <string name="start_of_your_card_description">Start of your card description...</string>
     <string name="card_description_fragment_header">Description</string>
+    <string name="done_text">Done</string>
+    <string name="cancel_text">Cancel</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,4 +24,6 @@
     <string name="boardActivity_boardNamePlaceholderText">Board Name</string>
     <string name="card_list_name_placeholder">Card List Name</string>
     <string name="CardList_addCard_text">+ Add Card</string>
+    <string name="start_of_your_card_description">Start of your card description...</string>
+    <string name="card_description_fragment_header">Description</string>
 </resources>


### PR DESCRIPTION
This pull will allow the user to edit the description by:

1. Clicking on the Description box on a Card, which opens the CardDescriptionEditorFragment.
2. Type words into the field.
3. Click "Done" to save the description, or "Cancel" to discard changes. The CardDescriptionEditorFragment then closes.

This fixes #21.