### PR TITLE
Allows user to delete a Card

### DIFF
--- a/app/src/main/java/com/example/projectmanager_android/CardExpandedFragment.java
+++ b/app/src/main/java/com/example/projectmanager_android/CardExpandedFragment.java
@@ -5,9 +5,14 @@ import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
 
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
 
 import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageButton;
@@ -15,6 +20,8 @@ import android.widget.TextView;
 
 import com.example.projectmanager_android.DB.AppDataBase;
 import com.example.projectmanager_android.DB.Card;
+
+import java.util.zip.Inflater;
 
 /**
  * A simple {@link Fragment} subclass.
@@ -64,6 +71,7 @@ public class CardExpandedFragment extends Fragment {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setHasOptionsMenu(true);
         if (getArguments() != null) {
             mCardTitleParam = getArguments().getString(CARD_TITLE_PARAM);
             mCardDescParam = getArguments().getString(CARD_DESC_PARAM);
@@ -76,6 +84,26 @@ public class CardExpandedFragment extends Fragment {
         // Inflate the layout for this fragment
 
         View view = inflater.inflate(R.layout.fragment_card_expanded, container, false);
+
+        Toolbar toolbar = view.findViewById(R.id.cardDescFragment_toolbar);
+        ((AppCompatActivity) requireActivity()).setSupportActionBar(toolbar);
+
+        toolbar.setNavigationOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                removeFragment();
+            }
+        });
+
+        toolbar.setOnMenuItemClickListener(new Toolbar.OnMenuItemClickListener() {
+            @Override
+            public boolean onMenuItemClick(MenuItem item) {
+                if(item.getItemId() == R.id.deleteCard_item){
+                    createDeleteCardDialogue();
+                }
+                return false;
+            }
+        });
 
         mCardTitle = view.findViewById(R.id.cardFragment_title);
         mCardDescription = view.findViewById(R.id.cardFragment_descriptionTextView);
@@ -96,7 +124,6 @@ public class CardExpandedFragment extends Fragment {
         mOptionsButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                // TODO: For now, open a dialogue box asking if the user wants to delete the card
                 createDeleteCardDialogue();
                 // TODO: Open a menu which contains a "Delete card" item
             }
@@ -157,4 +184,11 @@ public class CardExpandedFragment extends Fragment {
         AppDataBase.getInstance(getContext()).CardDAO().delete(mCard);
         removeFragment();
     }
+
+    @Override
+    public void onCreateOptionsMenu(Menu menu, MenuInflater menuInflater){
+        menuInflater.inflate(R.menu.card_menu, menu);
+        super.onCreateOptionsMenu(menu, menuInflater);
+    }
+
 }

--- a/app/src/main/res/drawable/baseline_close_24_white.xml
+++ b/app/src/main/res/drawable/baseline_close_24_white.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_card_expanded.xml
+++ b/app/src/main/res/layout/fragment_card_expanded.xml
@@ -10,35 +10,17 @@
     android:longClickable="true"
     >
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/cardFragment_UpperOptionsLayout"
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/cardDescFragment_toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:background="#1e1e1e"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        android:orientation="horizontal"
-        >
-        <ImageButton
-            android:id="@+id/cardFragment_exitButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:src="@drawable/baseline_close_24"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            />
-        <ImageButton
-            android:id="@+id/cardFragment_toolbarButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            android:backgroundTint="#1e1e1e"
-            android:src="@drawable/baseline_more_horiz_24_white"
-            />
-    </androidx.constraintlayout.widget.ConstraintLayout>
+        app:menu="@menu/card_menu"
+        app:navigationIcon="@drawable/baseline_close_24_white"
+        />
 
     <LinearLayout
         android:id="@+id/CardFragment_information"
@@ -46,7 +28,7 @@
         android:layout_height="wrap_content"
         android:orientation="vertical"
 
-        app:layout_constraintTop_toBottomOf="@+id/cardFragment_UpperOptionsLayout"
+        app:layout_constraintTop_toBottomOf="@+id/cardDescFragment_toolbar"
         >
         <LinearLayout
             android:id="@+id/cardFragment_titleLayout"

--- a/app/src/main/res/menu/card_menu.xml
+++ b/app/src/main/res/menu/card_menu.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    >
+    <item
+        android:id="@+id/deleteCard_item"
+        android:title="Delete card"/>
+
+</menu>


### PR DESCRIPTION
This pull allows the user to delete a card by:
* Clicking on a Card View to enter it's fragment.
* Clicking on the toolbar's menu options
* Clicking the "Delete Card" item, which opens the Alert Dialog "Remove Card".
* Clicking "Delete" on this Alert Dialog.

This fixes #24.
 